### PR TITLE
Add the spring-boot-starter-web dependency in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }


### PR DESCRIPTION
Without this dependency, the app starts but immediately finishes:
```
2:00:27 AM: Executing ':bootRun'…

> Task :compileJava
> Task :processResources UP-TO-DATE
> Task :classes
> Task :resolveMainClassName UP-TO-DATE

> Task :bootRun

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.4.1)

2024-12-29T02:00:30.302-05:00  INFO 1430 --- [website] [           main] c.t.website.WebsiteApplication           : Starting WebsiteApplication using Java 21.0.5 with PID 1430 (/home/brian/IdeaProjects/website/build/classes/java/main started by brian in /home/brian/IdeaProjects/website)
2024-12-29T02:00:30.305-05:00  INFO 1430 --- [website] [           main] c.t.website.WebsiteApplication           : No active profile set, falling back to 1 default profile: "default"
2024-12-29T02:00:30.834-05:00  INFO 1430 --- [website] [           main] c.t.website.WebsiteApplication           : Started WebsiteApplication in 1.001 seconds (process running for 1.887)

BUILD SUCCESSFUL in 3s
4 actionable tasks: 2 executed, 2 up-to-date
2:00:30 AM: Execution finished ':bootRun'.
```

Now the app starts and continues running like it's supposed to.